### PR TITLE
Camcorder support

### DIFF
--- a/res/xml/devices.xml
+++ b/res/xml/devices.xml
@@ -65,4 +65,9 @@
         <model>RX100 mk3</model>
         <webservice>http://192.168.122.1:8080/sony/camera</webservice>
     </camera>
+    <camera>
+        <id>14</id>
+        <model>HDR-PJ530</model>
+        <webservice>http://10.0.0.1:10000/sony/camera</webservice>
+    </camera>
 </cameras>

--- a/src/com/thibaudperso/sonycamera/sdk/CameraIO.java
+++ b/src/com/thibaudperso/sonycamera/sdk/CameraIO.java
@@ -54,6 +54,18 @@ public class CameraIO {
 		mCameraWS.setWSUrl(device.getWebService());
 	}
 
+	/**
+	 * Sets the shoot mode, "still" or "movie". This needs to be set to "still"
+	 * on some camcorders, because they default to video.
+	 *
+	 * @param mode
+	 *            either "still" or "movie".
+	 */
+	public void setShootMode(String mode) {
+		JSONArray params = new JSONArray().put(mode);
+		mCameraWS.sendRequest("setShootMode", params, null);
+	}
+
 	public void takePicture(final TakePictureListener listener) {
 		mCameraWS.sendRequest("actTakePicture", new JSONArray(), getTakePictureListener(listener));
 	}

--- a/src/com/thibaudperso/sonycamera/timelapse/fragments/ConnectionFragment.java
+++ b/src/com/thibaudperso/sonycamera/timelapse/fragments/ConnectionFragment.java
@@ -233,6 +233,8 @@ public class ConnectionFragment extends StepFragment implements WifiListener {
 					mCameraIO.initWebService(null);
 				}
 
+				mCameraIO.setShootMode("still");
+
 				if(getActivity() == null) {
 					return;
 				}


### PR DESCRIPTION
It turns out some camcorders have "movie" as default, rather than "still". This update just makes a call that sets the mode to "still", after the connection to the camera has been made.

Also, I added my HDR-PJ530 to devices.xml, since works fine now.