### PR TITLE
Improve connection and exit procedure

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -23,6 +23,7 @@
         <font color="#FF8888">Steuerung mit Smartphone</font> Modus 
         oder verknüpfe sie mit NFC (falls möglich)]]></string>
         
+    <string name="connection_close_app">Zum Beenden ein zweites Mal drücken.</string>
     <string name="connection_info">Verbindungsinformation</string>
     <string name="connection_refresh">Verbindung aktualisieren</string>
     <string name="connection_info_nothing">Warte auf weitere Informationen</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -22,6 +22,7 @@
     <string name="connection_information_message"><![CDATA[Mettez votre appareil dans le mode <font color="#FF8888">Contrôl. via smartph.</font> 
         ou pairrez le par NFC (si c\'est possible)]]></string>
     
+    <string name="connection_close_app">Press a second time to exit.</string> <!-- TODO  -->
     <string name="connection_info">Informations de connexion</string>
     <string name="connection_refresh">Rafraichir la connexion</string>
     <string name="connection_info_nothing">En attente de plus d\'informations</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="connection_information_message"><![CDATA[Put your camera in <font color="#FF8888">Ctrl with Smartphone</font> mode 
         or pair it by NFC (if it\'s possible)]]></string>
         
+    <string name="connection_close_app">Press a second time to exit.</string>
     <string name="connection_info">Connection information</string>
     <string name="connection_refresh">Refresh connection</string>
     <string name="connection_info_nothing">Waiting more information</string>

--- a/src/com/thibaudperso/sonycamera/io/WifiHandler.java
+++ b/src/com/thibaudperso/sonycamera/io/WifiHandler.java
@@ -19,6 +19,7 @@ public class WifiHandler {
 
 	private Context mContext;
 	private WifiManager mWifiManager;
+	private boolean wasWifiDisabled;
 	private WifiInfo lastWifiConnected;
 	private NetworkInfo.State cameraWifiState;
 
@@ -28,6 +29,7 @@ public class WifiHandler {
 
 		this.mContext = context;
 		mWifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE); 
+		wasWifiDisabled = mWifiManager.getWifiState() == WifiManager.WIFI_STATE_DISABLED;
 		mWifiManager.setWifiEnabled(true);
 		listeners = new ArrayList<WifiListener>();
 
@@ -141,17 +143,6 @@ public class WifiHandler {
 		mWifiManager.saveConfiguration();
 
 		return netId;
-	}
-
-
-	public void reconnectToLastWifi() {
-
-		if(lastWifiConnected != null) {
-			mWifiManager.enableNetwork(lastWifiConnected.getNetworkId(), true);
-
-			// Maybe remove comment on this line for more logic
-			//lastWifiConnected = null;
-		}
 	}
 
 	private static boolean isSonyCameraSSID(String ssid) {
@@ -295,5 +286,20 @@ public class WifiHandler {
 			return ssid.substring(1, ssid.length()-1);
 		}
 		return ssid;
+	}
+	
+	public void disconnect(){
+		unregister();
+		//reconnect to last wifi
+		if(lastWifiConnected != null && lastWifiConnected.getNetworkId() != -1) {
+			mWifiManager.enableNetwork(lastWifiConnected.getNetworkId(), true);
+		} else {
+			//no previous wifi: just disconnect from the camera's
+			mWifiManager.disconnect();
+			//disable wifi as well if it was disabled on app start
+			if(wasWifiDisabled)
+				mWifiManager.setWifiEnabled(false);
+		}
+		
 	}
 }

--- a/src/com/thibaudperso/sonycamera/sdk/CameraIO.java
+++ b/src/com/thibaudperso/sonycamera/sdk/CameraIO.java
@@ -195,6 +195,27 @@ public class CameraIO {
 		}, timeout);
 
 	}
+	
+	public void closeConnection() {
+
+		// Not enough
+		// mCameraWS.testConnection(timeout, listener);
+
+		mCameraWS.sendRequest("stopRecMode", new JSONArray(), new CameraWSListener() {
+
+			@Override
+			public void cameraResponse(JSONArray jsonResponse) {
+				Log.w("DEBUG","success closing connection.");			
+			}
+
+			@Override
+			public void cameraError(JSONObject jsonResponse) {	
+				Log.w("DEBUG","error closing connection.");				
+			}
+		}, 200);
+
+	}
+
 
 	public void startLiveView(final StartLiveviewListener listener) {
 

--- a/src/com/thibaudperso/sonycamera/timelapse/fragments/ConnectionFragment.java
+++ b/src/com/thibaudperso/sonycamera/timelapse/fragments/ConnectionFragment.java
@@ -167,7 +167,13 @@ public class ConnectionFragment extends StepFragment implements WifiListener {
 	@Override
 	public void onWifiConnected(String ssid) {
 		setConnectionInfoMessage(R.string.connection_info_wifi_connected, ssid);
-		checkWSConnection();
+		//before checking connection: give the camera some time to adjust to the new connection
+	    android.os.Handler handler = new android.os.Handler(); 
+	    handler.postDelayed(new Runnable() { 
+	         public void run() { 
+	     		checkWSConnection();
+	         } 
+	    }, 300);
 	}
 
 	@Override
@@ -229,11 +235,12 @@ public class ConnectionFragment extends StepFragment implements WifiListener {
 			@Override
 			public void cameraConnected(final boolean isConnected) {
 
-				if(isConnected && mDeviceManager.getSelectedDevice() != null && mDeviceManager.getSelectedDevice().needInit()) {
-					mCameraIO.initWebService(null);
+				if(isConnected && mDeviceManager.getSelectedDevice() != null) {
+					if(mDeviceManager.getSelectedDevice().needInit()){
+						mCameraIO.initWebService(null);
+					}
+					mCameraIO.setShootMode("still");
 				}
-
-				mCameraIO.setShootMode("still");
 
 				if(getActivity() == null) {
 					return;

--- a/src/com/thibaudperso/sonycamera/timelapse/ui/TimelapseStepsActivity.java
+++ b/src/com/thibaudperso/sonycamera/timelapse/ui/TimelapseStepsActivity.java
@@ -27,6 +27,7 @@ import com.thibaudperso.sonycamera.R;
 import com.thibaudperso.sonycamera.io.NFCHandler;
 import com.thibaudperso.sonycamera.io.WifiHandler;
 import com.thibaudperso.sonycamera.io.WifiListener;
+import com.thibaudperso.sonycamera.sdk.CameraIO;
 import com.thibaudperso.sonycamera.timelapse.StepCompletedListener;
 import com.thibaudperso.sonycamera.timelapse.StepFragment;
 import com.thibaudperso.sonycamera.timelapse.TimelapseApplication;
@@ -68,6 +69,8 @@ FinishFragmentListener, CaptureFragmentListener {
 
 	private TextView informationTextView;
 	private ImageView informationImage;
+	
+	private boolean doubleBackToExitPressedOnce = false;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -169,9 +172,9 @@ FinishFragmentListener, CaptureFragmentListener {
 			fragmentsArray[lastPositionSelected].onExitFragment();
 		}
 
+		//disconnect from camera's wifi network
 		if(mWifiHandler != null) {
-			mWifiHandler.reconnectToLastWifi();
-			mWifiHandler.unregister();
+			mWifiHandler.disconnect();
 			mWifiHandler.removeListener(this);
 		}
 
@@ -309,6 +312,11 @@ FinishFragmentListener, CaptureFragmentListener {
 
 		case R.id.action_next:
 			if(mPager.getCurrentItem() == mPagerAdapter.getCount() - 1) {
+				//tell the camera we're done
+				CameraIO mCameraIO = ((TimelapseApplication) this.getApplication()).getCameraIO();
+				if(mCameraIO != null)
+					mCameraIO.closeConnection();
+				//continue with closing procedure, including wifi disconnection
 				finish();
 				return true;
 			}
@@ -327,18 +335,32 @@ FinishFragmentListener, CaptureFragmentListener {
 
 	@Override
 	public void onBackPressed() {
-		if (mPager.getCurrentItem() == 0) {
-			// If the user is currently looking at the first step, allow the system to handle the
-			// Back button. This calls finish() on this activity and pops the back stack.
-			super.onBackPressed();
-			exit();
+		//exit only on second press
+		if(doubleBackToExitPressedOnce){
+			if (mPager.getCurrentItem() == 0) {
+				// If the user is currently looking at the first step, allow the system to handle the
+				// Back button. This calls finish() on this activity and pops the back stack.
+				super.onBackPressed();
+				exit();
+			} else {
+				// Otherwise, select the previous step.
+				int newItem = mPager.getCurrentItem() - 1;
+				//CaptureFragment can't be reached by BackPressed, jump to CaptureSettings instead 
+				if(newItem == 3)
+					newItem--;
+				mPager.setCurrentItem(newItem);
+			}
 		} else {
-			// Otherwise, select the previous step.
-			int newItem = mPager.getCurrentItem() - 1;
-			//CaptureFragment can't be reached by BackPressed, jump to CaptureSettings instead 
-			if(newItem == 3)
-				newItem--;
-			mPager.setCurrentItem(newItem);
+			//first press is okay
+			this.doubleBackToExitPressedOnce = true;
+			Toast.makeText(this, R.string.connection_close_app, Toast.LENGTH_SHORT).show();
+			//reset first press if 2 seconds have passed without further press
+		    new android.os.Handler().postDelayed(new Runnable() {
+		        @Override
+		        public void run() {
+		            doubleBackToExitPressedOnce=false;                       
+		        }
+		    }, 2000);
 		}
 	}
 


### PR DESCRIPTION
- I noticed the connection to my camera shows each time an error even though everything is fine. Now the app waits for a short time (300ms) after the phone is connected to the camera in order to give time for adjustements before checking the connection with a "getVersions"-call.

- In addition i improved the exit procedure a bit. Now an api-call "stopRecMode" is made and after that the phone disconnects from the camera's wifi before connecting again to the previously used network or disabling wifi. This should be tested on an RX-camera - i'm not sure "stopRecMode" works there as expected, but hope this won't be a problem.