### PR TITLE
DSC-WX80: fix link

### DIFF
--- a/app/src/main/res/raw/devices.xml
+++ b/app/src/main/res/raw/devices.xml
@@ -58,7 +58,7 @@
     <camera>
         <id>12</id>
         <model>DSC-WX80</model>
-        <webservice>http://10.0.0.1:10000/camera</webservice>
+        <webservice>http://10.0.0.1:10000/sony/camera</webservice>
     </camera>
     <camera>
         <id>13</id>


### PR DESCRIPTION
I own a DSC-WX80 camera and tried to connect using TimeLapse 3.0.6.
It can connect to the WiFi but fails at "Sony API conenction".
The RetrieveSonyCameraIP app showed the following address:
http://10.0.0.1:10000/sony/camera
This is very similar to all other links in devices.xml (with
"sony" in the path).
Opening the link in a browser return an XML file, including the
camera UID.
I did not test the modified application. I tried to compile it
briefly but an error occurred and I would only spend more
debugging time if required.