### PR TITLE
Adding the RX100VA to the supported devices

### DIFF
--- a/app/src/main/res/raw/devices.xml
+++ b/app/src/main/res/raw/devices.xml
@@ -220,4 +220,9 @@
         <model>FDR-AX100E</model>
         <webservice>http://10.0.0.1:10000/sony/camera</webservice>
     </camera>
+    <camera>
+        <id>45</id>
+        <model>RX100 VA</model>
+        <webservice>http://192.168.122.1:10000/sony/camera</webservice>
+    </camera>
 </cameras>


### PR DESCRIPTION
RX100 VA works with the 192.168.122.1 IP adress and the 10000 port number, like the RX100VI