### PR TITLE
Add compatiblity with Android 9

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
                                         com.google.android.gms.safetynet,
                                         com.google.android.gms.tasks,
                                         com.google.android.gms"/>
-
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.NFC"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
@@ -21,13 +20,20 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name=".timelapse.TimelapseApplication"
         android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
+
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+
         <activity
             android:name=".timelapse.ui.connection.ConnectionActivity"
             android:label="@string/app_name"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>10.0.0.1</domain>
+        <domain>192.168.122.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
I don't know much about Android development, but with the following changes TimeLapse seems to work fine on LineageOS 16.0 (based on Android 9) on a `flo` device. Feel free to do so more tests or documentation. :)